### PR TITLE
Harden 1.9.16 crash-prone formatting and native checks

### DIFF
--- a/__tests__/utils/localeSafe.test.ts
+++ b/__tests__/utils/localeSafe.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2025-2026 Velimir Majstorov
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import {
+  compareStrings,
+  compareStringsCaseInsensitive,
+  formatClockTime,
+  formatLocalDateTime,
+} from '../../src/utils/localeSafe';
+
+describe('localeSafe', () => {
+  it('formats clock time without Intl/locale APIs', () => {
+    const morning = new Date(2026, 4, 18, 9, 5).getTime();
+    const afternoon = new Date(2026, 4, 18, 15, 4).getTime();
+    const midnight = new Date(2026, 4, 18, 0, 0).getTime();
+
+    expect(formatClockTime(morning, '24h')).toBe('09:05');
+    expect(formatClockTime(afternoon, '24h')).toBe('15:04');
+    expect(formatClockTime(morning, '12h')).toBe('09:05 AM');
+    expect(formatClockTime(afternoon, '12h')).toBe('03:04 PM');
+    expect(formatClockTime(midnight, '12h')).toBe('12:00 AM');
+  });
+
+  it('formats local date time without Intl/locale APIs', () => {
+    const timestamp = new Date(2026, 0, 2, 3, 4).getTime();
+
+    expect(formatLocalDateTime(timestamp)).toBe('2026-01-02 03:04');
+  });
+
+  it('handles invalid timestamps like Date locale formatters do', () => {
+    expect(formatClockTime(Number.NaN, '24h')).toBe('Invalid Date');
+    expect(formatLocalDateTime(Number.NaN)).toBe('Invalid Date');
+  });
+
+  it('compares strings without constructing Intl collators', () => {
+    expect(compareStrings('alpha', 'zebra')).toBeLessThan(0);
+    expect(compareStrings('same', 'same')).toBe(0);
+    expect(compareStringsCaseInsensitive('Beta', 'alpha')).toBeGreaterThan(0);
+    expect(compareStringsCaseInsensitive('Alpha', 'alpha')).toBeLessThan(0);
+  });
+});

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -244,8 +244,8 @@ android {
         applicationId = "com.androidircx"
         minSdkVersion = rootProject.ext.minSdkVersion
         targetSdkVersion = rootProject.ext.targetSdkVersion
-        versionCode = 118
-        versionName = "1.9.15"
+        versionCode = 119
+        versionName = "1.9.16"
 
         buildConfigField "long", "PLAY_INTEGRITY_PROJECT_NUMBER", "1060587657852L"
 
@@ -301,9 +301,11 @@ android {
         }
         pickFirst '**/libreactnative.so'
         pickFirst '**/libc++_shared.so'
-        pickFirst '**/libhermes.so'
+        pickFirst '**/libhermesvm.so'
+        pickFirst '**/libhermestooling.so'
         pickFirst '**/libjsc.so'
         pickFirst '**/libfbjni.so'
+        pickFirst '**/libjsi.so'
         pickFirst '**/libyoga.so'
         pickFirst '**/libfolly_runtime.so'
         pickFirst '**/libglog.so'

--- a/android/fastlane/fastlane/metadata/android/en-US/changelogs/119.txt
+++ b/android/fastlane/fastlane/metadata/android/en-US/changelogs/119.txt
@@ -1,0 +1,5 @@
+What's new in 1.9.16:
+- Updated dependencies
+- Reduced Hermes memory pressure by replacing hot timestamp formatting and sorting paths that used Android ICU/Collator
+- Added safer timestamp rendering for message, script, and channel activity lists
+- Added a release artifact check for React Native/Hermes native libraries across supported ABIs

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "name": "AndroidIRCX",
   "displayName": "AndroidIRCX",
-  "version": "1.9.15",
+  "version": "1.9.16",
   "react-native-google-mobile-ads": {
     "android_app_id": "ca-app-pub-5116758828202889~3198641840"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "androidircx",
-  "version": "1.9.15",
+  "version": "1.9.16",
   "private": true,
   "license": "GPL-3.0-or-later",
   "scripts": {
@@ -48,7 +48,7 @@
     "react-native-config": "^1.6.1",
     "react-native-fs": "^2.20.0",
     "react-native-google-mobile-ads": "^16.3.3",
-    "react-native-iap": "15.2.3",
+    "react-native-iap": "15.2.4",
     "react-native-keyboard-controller": "1.21.7",
     "react-native-keychain": "^10.0.0",
     "react-native-libsodium": "^1.7.0",
@@ -90,7 +90,7 @@
     "@testing-library/react-native": "^13.3.3",
     "@transifex/cli": "^7.1.6",
     "@types/jest": "29.5.14",
-    "@types/node": "25.7.0",
+    "@types/node": "25.8.0",
     "@types/node-forge": "^1.3.14",
     "@types/react": "^19.2.14",
     "@types/react-test-renderer": "^19.1.0",

--- a/scripts/verify-android-native-libs.ps1
+++ b/scripts/verify-android-native-libs.ps1
@@ -1,0 +1,56 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$ArtifactPath,
+
+    [string[]]$Architectures = @(
+        "armeabi-v7a",
+        "arm64-v8a",
+        "x86",
+        "x86_64"
+    ),
+
+    [string[]]$Libraries = @(
+        "libreactnative.so",
+        "libhermesvm.so",
+        "libc++_shared.so",
+        "libfbjni.so",
+        "libjsi.so"
+    )
+)
+
+$resolvedArtifact = Resolve-Path -LiteralPath $ArtifactPath -ErrorAction Stop
+
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+
+$zip = [System.IO.Compression.ZipFile]::OpenRead($resolvedArtifact.Path)
+try {
+    $entryNames = [System.Collections.Generic.HashSet[string]]::new(
+        [System.StringComparer]::Ordinal
+    )
+
+    foreach ($entry in $zip.Entries) {
+        [void]$entryNames.Add($entry.FullName)
+    }
+
+    $missing = New-Object System.Collections.Generic.List[string]
+
+    foreach ($abi in $Architectures) {
+        foreach ($library in $Libraries) {
+            $apkEntry = "lib/$abi/$library"
+            $aabEntry = "base/lib/$abi/$library"
+
+            if (-not ($entryNames.Contains($apkEntry) -or $entryNames.Contains($aabEntry))) {
+                $missing.Add("$abi/$library")
+            }
+        }
+    }
+
+    if ($missing.Count -gt 0) {
+        Write-Error "Missing native libraries in $($resolvedArtifact.Path): $($missing -join ', ')"
+        exit 1
+    }
+
+    Write-Output "Native library check passed for $($resolvedArtifact.Path)"
+} finally {
+    $zip.Dispose()
+}

--- a/src/components/ChannelLogModal.tsx
+++ b/src/components/ChannelLogModal.tsx
@@ -5,6 +5,7 @@
 
 import React from 'react';
 import { Modal, TouchableOpacity, View, Text } from 'react-native';
+import { formatLocalDateTime } from '../utils/localeSafe';
 
 interface LogEntry {
   timestamp: number;
@@ -46,7 +47,7 @@ export const ChannelLogModal: React.FC<ChannelLogModalProps> = ({
             ) : (
               logEntries.map((entry, idx) => (
                 <Text key={`log-${idx}`} style={styles.optionText}>
-                  {new Date(entry.timestamp).toLocaleString()} - {entry.text}
+                  {formatLocalDateTime(entry.timestamp)} - {entry.text}
                 </Text>
               ))
             )}

--- a/src/components/MessageArea.tsx
+++ b/src/components/MessageArea.tsx
@@ -93,6 +93,7 @@ import { SoundEventType } from '../types/sound';
 import { useUIStore } from '../stores/uiStore';
 import KickBanModal from './KickBanModal';
 import { debugLogger } from '../services/DebugLogger';
+import { formatClockTime } from '../utils/localeSafe';
 
 interface MessageAreaProps {
   messages: IRCMessage[];
@@ -257,19 +258,7 @@ const MessageItem = React.memo<MessageItemProps>(
 
     const formatTimestamp = useCallback(
       (timestamp: number): string => {
-        const date = new Date(timestamp);
-        if (timestampFormat === '24h') {
-          return date.toLocaleTimeString('en-US', {
-            hour: '2-digit',
-            minute: '2-digit',
-            hour12: false,
-          });
-        } else {
-          return date.toLocaleTimeString('en-US', {
-            hour: '2-digit',
-            minute: '2-digit',
-          });
-        }
+        return formatClockTime(timestamp, timestampFormat);
       },
       [timestampFormat],
     );
@@ -2950,18 +2939,7 @@ export const MessageArea: React.FC<MessageAreaProps> = ({
     if (!selected.length) return;
 
     const formatTimestamp = (timestamp: number): string => {
-      const date = new Date(timestamp);
-      if (layoutState.timestampFormat === '24h') {
-        return date.toLocaleTimeString('en-US', {
-          hour: '2-digit',
-          minute: '2-digit',
-          hour12: false,
-        });
-      }
-      return date.toLocaleTimeString('en-US', {
-        hour: '2-digit',
-        minute: '2-digit',
-      });
+      return formatClockTime(timestamp, layoutState.timestampFormat);
     };
 
     const sorted = [...selected].sort((a, b) => a.timestamp - b.timestamp);

--- a/src/components/MessageInput.tsx
+++ b/src/components/MessageInput.tsx
@@ -32,6 +32,7 @@ import { IRC_FORMAT_CODES } from '../utils/IRCFormatter';
 import { repairMojibake } from '../utils/EncodingUtils';
 import { ColorPalettePicker } from './ColorPalettePicker';
 import { useServiceCommands } from '../hooks/useServiceCommands';
+import { compareStringsCaseInsensitive } from '../utils/localeSafe';
 
 type MessageInputSuggestion = {
   text: string;
@@ -703,7 +704,7 @@ export const MessageInput: React.FC<MessageInputProps> = ({
         .filter(item => item.text.toLowerCase().startsWith(typedLower))
         .sort((a, b) => {
           if (b.score !== a.score) return b.score - a.score;
-          return a.text.localeCompare(b.text);
+          return compareStringsCaseInsensitive(a.text, b.text);
         })
         .slice(0, 6);
 
@@ -754,7 +755,7 @@ export const MessageInput: React.FC<MessageInputProps> = ({
       const tokenLower = token.toLowerCase();
       nickMatches = Array.from(nickSet.values())
         .filter(nick => nick.toLowerCase().startsWith(tokenLower))
-        .sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()))
+        .sort(compareStringsCaseInsensitive)
         .slice(0, 6)
         .map(nick => ({ text: nick, source: 'nick' as const }));
     }
@@ -781,7 +782,7 @@ export const MessageInput: React.FC<MessageInputProps> = ({
         const rawLower = rawToken.toLowerCase();
         channelMatches = Array.from(chanSet.values())
           .filter(ch => ch.toLowerCase().startsWith(rawLower))
-          .sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()))
+          .sort(compareStringsCaseInsensitive)
           .slice(0, 6)
           .map(ch => ({ text: ch, source: 'channel' as const }));
       }

--- a/src/components/UserList.tsx
+++ b/src/components/UserList.tsx
@@ -62,6 +62,7 @@ import { useUIStore } from '../stores/uiStore';
 import { NickContextMenu } from './NickContextMenu';
 import { useDebounce } from '../hooks/useDebounce';
 import { webRtcCallService } from '../services/WebRTCCallService';
+import { compareStringsCaseInsensitive } from '../utils/localeSafe';
 
 // Note: This function cannot use useT() as it's exported outside the component
 // The translation will be handled where it's called
@@ -380,9 +381,7 @@ export const UserList: React.FC<UserListProps> = ({
 
     // Sort each group alphabetically
     Object.keys(groups).forEach(key => {
-      groups[key].sort((a, b) =>
-        a.nick.toLowerCase().localeCompare(b.nick.toLowerCase()),
-      );
+      groups[key].sort((a, b) => compareStringsCaseInsensitive(a.nick, b.nick));
     });
 
     return groups;
@@ -419,7 +418,7 @@ export const UserList: React.FC<UserListProps> = ({
       }
 
       // Then sort alphabetically by nick
-      return a.nick.toLowerCase().localeCompare(b.nick.toLowerCase());
+      return compareStringsCaseInsensitive(a.nick, b.nick);
     });
   }, [users, shouldSkipSort]);
 

--- a/src/components/modals/NetworkPickerModal.tsx
+++ b/src/components/modals/NetworkPickerModal.tsx
@@ -25,6 +25,7 @@ import {
 } from '../../services/SettingsService';
 import { useTheme } from '../../hooks/useTheme';
 import { useT } from '../../i18n/transifex';
+import { compareStringsCaseInsensitive } from '../../utils/localeSafe';
 
 interface NetworkPickerModalProps {
   visible: boolean;
@@ -58,7 +59,7 @@ export const NetworkPickerModal: React.FC<NetworkPickerModalProps> = ({
       const sorted = [...loadedNetworks].sort((a, b) => {
         if (a.name === recommendedNetworkId) return -1;
         if (b.name === recommendedNetworkId) return 1;
-        return a.name.localeCompare(b.name);
+        return compareStringsCaseInsensitive(a.name, b.name);
       });
       setNetworks(sorted);
     } catch (error) {

--- a/src/screens/MessageHistoryViewerScreen.tsx
+++ b/src/screens/MessageHistoryViewerScreen.tsx
@@ -28,6 +28,10 @@ import { useT } from '../i18n/transifex';
 import { IRCMessage } from '../services/IRCService';
 import { messageHistoryService } from '../services/MessageHistoryService';
 import { formatIRCTextAsComponent } from '../utils/IRCFormatter';
+import {
+  compareStringsCaseInsensitive,
+  formatLocalDateTime,
+} from '../utils/localeSafe';
 
 interface MessageHistoryViewerScreenProps {
   visible: boolean;
@@ -110,9 +114,9 @@ export const MessageHistoryViewerScreen: React.FC<
       const list = await messageHistoryService.listStoredChannels();
       const sorted = [...list].sort((a, b) => {
         if (a.network !== b.network) {
-          return a.network.localeCompare(b.network);
+          return compareStringsCaseInsensitive(a.network, b.network);
         }
-        return a.channel.localeCompare(b.channel);
+        return compareStringsCaseInsensitive(a.channel, b.channel);
       });
       setEntries(sorted);
     } finally {
@@ -326,7 +330,7 @@ export const MessageHistoryViewerScreen: React.FC<
     <View style={styles.messageRow}>
       <View style={styles.messageInfo}>
         <Text style={styles.messageMeta}>
-          {new Date(item.timestamp).toLocaleString()}{' '}
+          {formatLocalDateTime(item.timestamp)}{' '}
           {item.from ? `· ${item.from}` : ''}
         </Text>
         {formatIRCTextAsComponent(item.text, styles.messageText)}

--- a/src/screens/ScriptingScreen.tsx
+++ b/src/screens/ScriptingScreen.tsx
@@ -33,6 +33,7 @@ import { inAppPurchaseService } from '../services/InAppPurchaseService';
 import { useTheme } from '../hooks/useTheme';
 import { useT } from '../i18n/transifex';
 import Prism from 'prismjs';
+import { formatClockTime } from '../utils/localeSafe';
 import 'prismjs/components/prism-clike';
 import 'prismjs/components/prism-javascript';
 
@@ -652,8 +653,7 @@ export const ScriptingScreen: React.FC<Props> = ({
             )}
             {filteredLogs.map(log => (
               <Text key={log.id} style={styles.logLine}>
-                [{new Date(log.ts).toLocaleTimeString()}]{' '}
-                {log.level.toUpperCase()}{' '}
+                [{formatClockTime(log.ts, '24h')}] {log.level.toUpperCase()}{' '}
                 {log.scriptId ? `[${log.scriptId}]` : ''} {log.message}
               </Text>
             ))}

--- a/src/services/EncryptedDMService.ts
+++ b/src/services/EncryptedDMService.ts
@@ -8,6 +8,7 @@ import { x25519 } from '@noble/curves/ed25519.js';
 import { TextEncoder, TextDecoder } from 'text-encoding';
 import { secureStorageService } from './SecureStorageService';
 import { tx } from '../i18n/transifex';
+import { compareStringsCaseInsensitive } from '../utils/localeSafe';
 
 const t = (key: string, params?: Record<string, unknown>) => tx.t(key, params);
 
@@ -1004,9 +1005,12 @@ class EncryptedDMService {
 
     // Sort by network, then nick
     return keys.sort((a, b) => {
-      const networkCompare = a.network.localeCompare(b.network);
+      const networkCompare = compareStringsCaseInsensitive(
+        a.network,
+        b.network,
+      );
       if (networkCompare !== 0) return networkCompare;
-      return a.nick.localeCompare(b.nick);
+      return compareStringsCaseInsensitive(a.nick, b.nick);
     });
   }
 

--- a/src/services/ServiceCommandProvider.ts
+++ b/src/services/ServiceCommandProvider.ts
@@ -15,6 +15,7 @@ import {
 } from '../interfaces/ServiceTypes';
 import { serviceDetectionService } from './ServiceDetectionService';
 import { getConfig } from '../config/services';
+import { compareStringsCaseInsensitive } from '../utils/localeSafe';
 
 /** Command search result */
 export interface CommandSearchResult {
@@ -374,7 +375,9 @@ export class ServiceCommandProvider {
       }
     }
 
-    return aliases.sort((a, b) => a.alias.localeCompare(b.alias));
+    return aliases.sort((a, b) =>
+      compareStringsCaseInsensitive(a.alias, b.alias),
+    );
   }
 
   /**

--- a/src/utils/localeSafe.ts
+++ b/src/utils/localeSafe.ts
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2025-2026 Velimir Majstorov
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+export type ClockFormat = '12h' | '24h';
+
+const pad2 = (value: number): string => value.toString().padStart(2, '0');
+
+const toValidDate = (timestamp: number): Date | null => {
+  const date = new Date(timestamp);
+  return Number.isNaN(date.getTime()) ? null : date;
+};
+
+export const formatClockTime = (
+  timestamp: number,
+  format: ClockFormat = '12h',
+): string => {
+  const date = toValidDate(timestamp);
+  if (!date) {
+    return 'Invalid Date';
+  }
+
+  const hours = date.getHours();
+  const minutes = pad2(date.getMinutes());
+
+  if (format === '24h') {
+    return `${pad2(hours)}:${minutes}`;
+  }
+
+  const suffix = hours >= 12 ? 'PM' : 'AM';
+  const hour12 = hours % 12 || 12;
+  return `${pad2(hour12)}:${minutes} ${suffix}`;
+};
+
+export const formatLocalDateTime = (timestamp: number): string => {
+  const date = toValidDate(timestamp);
+  if (!date) {
+    return 'Invalid Date';
+  }
+
+  return [
+    `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(
+      date.getDate(),
+    )}`,
+    `${pad2(date.getHours())}:${pad2(date.getMinutes())}`,
+  ].join(' ');
+};
+
+export const compareStrings = (a: string, b: string): number => {
+  if (a === b) {
+    return 0;
+  }
+  return a < b ? -1 : 1;
+};
+
+export const compareStringsCaseInsensitive = (a: string, b: string): number => {
+  const foldedA = a.toLowerCase();
+  const foldedB = b.toLowerCase();
+  const foldedCompare = compareStrings(foldedA, foldedB);
+  return foldedCompare !== 0 ? foldedCompare : compareStrings(a, b);
+};

--- a/src/utils/tabUtils.ts
+++ b/src/utils/tabUtils.ts
@@ -11,6 +11,7 @@
  */
 
 import { ChannelTab } from '../types';
+import { compareStringsCaseInsensitive } from './localeSafe';
 
 /**
  * Generate unique ID for server tab
@@ -73,7 +74,7 @@ export const sortTabsGrouped = (
     if (server) result.push(server);
     const others = tabs.filter(t => t.networkId === net && t.type !== 'server');
     if (sortAlphabetical) {
-      others.sort((a, b) => a.name.localeCompare(b.name));
+      others.sort((a, b) => compareStringsCaseInsensitive(a.name, b.name));
     }
     others.forEach(t => result.push(t));
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2854,12 +2854,12 @@
   dependencies:
     undici-types "~7.16.0"
 
-"@types/node@25.7.0":
-  version "25.7.0"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-25.7.0.tgz#7498f82e90dbdce7c34b75aaaa256c498a0ebe6c"
-  integrity sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg==
+"@types/node@25.8.0":
+  version "25.8.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-25.8.0.tgz#d13033397d1c186876bed4c9b9d7f3f962097eb3"
+  integrity sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ==
   dependencies:
-    undici-types "~7.21.0"
+    undici-types ">=7.24.0 <7.24.7"
 
 "@types/react-test-renderer@^19.1.0":
   version "19.1.0"
@@ -7423,10 +7423,10 @@ react-native-google-mobile-ads@^16.3.3:
     "@iabtcf/core" "^1.5.6"
     use-deep-compare-effect "^1.8.1"
 
-react-native-iap@15.2.3:
-  version "15.2.3"
-  resolved "https://registry.yarnpkg.com/react-native-iap/-/react-native-iap-15.2.3.tgz#e53df043894b6e46372d17e64f745ecbc4f49c3f"
-  integrity sha512-P+2vPAO3R5u1xLvsJR7ha00wYz5vfJBiis0REmR0vnW6evCBn6W6NAh2KxNIDPosu6LjHX/kiAs85LRD30BJpg==
+react-native-iap@15.2.4:
+  version "15.2.4"
+  resolved "https://registry.yarnpkg.com/react-native-iap/-/react-native-iap-15.2.4.tgz#cf3211f38b972f87038130b649340f811e09e2ac"
+  integrity sha512-sODkTABwL7J/S50yIkdsgTxWohehsEWAo4G+GyXjhoHO0t950ORY9uZ06YowvcC4iUgODee8CWA6DxjNAt7OXQ==
 
 react-native-is-edge-to-edge@^1.2.1, react-native-is-edge-to-edge@^1.3.1:
   version "1.3.1"
@@ -8522,15 +8522,15 @@ unbox-primitive@^1.1.0:
     has-symbols "^1.1.0"
     which-boxed-primitive "^1.1.1"
 
+"undici-types@>=7.24.0 <7.24.7":
+  version "7.24.6"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.24.6.tgz#61275b485d7fd4e9d269c7cf04ec2873c9cc0f91"
+  integrity sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==
+
 undici-types@~7.16.0:
   version "7.16.0"
   resolved "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz"
   integrity sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==
-
-undici-types@~7.21.0:
-  version "7.21.0"
-  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.21.0.tgz#433f7dd1b5daa9ab4dacb721a5e11a8de51eadda"
-  integrity sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ==
 
 unicode-canonical-property-names-ecmascript@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION


# Pull Request

## Summary

Reduce Hermes memory pressure by replacing hot locale-based timestamp formatting and string sorting paths. Add native library artifact verification and include the 1.9.16 dependency and release metadata updates.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Tooling / CI
- [ ] Documentation
- [ ] Dependency update

## Verification

- [x] `yarn format-check`
- [x] `yarn lint:ci`
- [x] `yarn type-check`
- [x] `yarn test:ci`

List any additional manual verification performed:

-

## Impact and Risk

- Describe user-facing impact.
- Call out migrations, config changes, or rollout risk.
- Note anything intentionally left for a follow-up PR.

## UI Changes

- [x] No UI changes
- [ ] UI changes included below

Screenshots or recordings:

-

## Checklist

- [ ] Tests added or updated when behavior changed
- [ ] Documentation updated when behavior, setup, or workflow changed
- [ ] PR is scoped and does not mix unrelated changes
- [ ] Security/privacy implications reviewed if relevant
