### PR TITLE
Bump concurrent-ruby pin to >= 1.3.7 (closes 3 Dependabot alerts)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ ruby ">= 2.6.10"
 gem 'cocoapods', '>= 1.13', '!= 1.15.0', '!= 1.15.1'
 gem 'activesupport', '>= 7.2.3.1', '!= 8.0.0', '!= 8.0.1', '!= 7.1.0'
 gem 'xcodeproj', '< 1.26.0'
-gem 'concurrent-ruby', '< 1.3.4'
+gem 'concurrent-ruby', '>= 1.3.7'
 
 # Ruby 3.4.0 has removed some libraries from the standard library.
 gem 'bigdecimal'


### PR DESCRIPTION
## Summary
Moves the `concurrent-ruby` pin in `Gemfile` from `< 1.3.4` to `>= 1.3.7` to close three Dependabot alerts:

- #90 -- `AtomicReference#update` livelocks when stored value is `Float::NAN` (**High**)
- #91 -- `ReentrantReadWriteLock` read-count overflow grants write lock without exclusivity (Low)
- #92 -- `ReadWriteLock` allows wrong-thread write release and stray read-release counter corruption (Low)

All three are fixed in concurrent-ruby 1.3.7.

The original `< 1.3.4` cap was added when 1.3.4 introduced a hard dependency on stdlib `logger`, which broke Ruby >= 3.4 setups. That issue is already mitigated by the explicit `gem 'logger'` line in the same Gemfile, so the cap can move forward safely.

## Scope of risk
`concurrent-ruby` is a build-time gem only (CocoaPods, fastlane on developer machines) -- not shipped in the AAB, never runs on user devices -- so the practical exposure is low. This PR is about closing the alerts and keeping the security dashboard clean.

## Test plan
- [ ] Tests workflow green on this PR
- [ ] No new alerts surface after merge
- [ ] Locally: `cd android && bundle install` resolves to a `concurrent-ruby >= 1.3.7` and `fastlane production` lane still runs