### PR TITLE
Add selectable text encoding and message font (v1.9.45)

### DIFF
--- a/__tests__/IRCService.lowlevel.test.ts
+++ b/__tests__/IRCService.lowlevel.test.ts
@@ -281,11 +281,53 @@ describe('IRCService low-level branches', () => {
   it('processes buffer with normal and empty lines', () => {
     const handleSpy = jest.spyOn(irc as any, 'handleIRCMessage');
     const wireSpy = jest.spyOn(irc as any, 'addWireMessage');
-    (irc as any).buffer = 'PING :a\r\n\r\nNOTICE x :y\r\npartial';
+    (irc as any).inboundBuffer = Buffer.from(
+      'PING :a\r\n\r\nNOTICE x :y\r\npartial',
+      'utf8',
+    );
     (irc as any).processBuffer();
     expect(handleSpy).toHaveBeenCalledTimes(2);
     expect(wireSpy).toHaveBeenCalled();
-    expect((irc as any).buffer).toBe('partial');
+    expect((irc as any).inboundBuffer.toString('utf8')).toBe('partial');
+  });
+
+  it('decodes inbound lines with the configured legacy encoding', () => {
+    const handleSpy = jest.spyOn(irc as any, 'handleIRCMessage');
+    (irc as any).config = { ...(irc as any).config, encoding: 'windows-1251' };
+    // "Привет" in Windows-1251 followed by CRLF.
+    (irc as any).inboundBuffer = Buffer.concat([
+      Buffer.from([0xcf, 0xf0, 0xe8, 0xe2, 0xe5, 0xf2]),
+      Buffer.from('\r\n', 'ascii'),
+    ]);
+    (irc as any).processBuffer();
+    expect(handleSpy).toHaveBeenCalledWith('Привет');
+  });
+
+  it('sendRaw encodes the line with the configured legacy encoding', () => {
+    const writeSpy = jest.fn();
+    (irc as any).socket.write = writeSpy;
+    (irc as any).config = { ...(irc as any).config, encoding: 'windows-1251' };
+    irc.sendRaw('Привет');
+    expect(writeSpy).toHaveBeenCalledTimes(1);
+    const arg = writeSpy.mock.calls[0][0];
+    expect(Buffer.isBuffer(arg)).toBe(true);
+    expect(Array.from(arg as Buffer)).toEqual([
+      0xcf, 0xf0, 0xe8, 0xe2, 0xe5, 0xf2, 0x0d, 0x0a,
+    ]);
+  });
+
+  it('sendRaw uses the plain string path for UTF-8', () => {
+    const writeSpy = jest.fn();
+    (irc as any).socket.write = writeSpy;
+    (irc as any).config = { ...(irc as any).config, encoding: 'utf-8' };
+    irc.sendRaw('hello');
+    expect(writeSpy).toHaveBeenCalledWith('hello\r\n');
+  });
+
+  it('setEncoding updates the active connection encoding', () => {
+    irc.setEncoding('koi8-r', true);
+    expect((irc as any).config.encoding).toBe('koi8-r');
+    expect((irc as any).config.utf8Fallback).toBe(true);
   });
 
   it('handles low-level IRC parsing branches', () => {

--- a/__tests__/components/MessageArea.test.tsx
+++ b/__tests__/components/MessageArea.test.tsx
@@ -171,6 +171,7 @@ jest.mock('../../src/services/LayoutService', () => ({
       messageTextWritingSystem: 'auto',
     })),
     getFontSizePixels: jest.fn(() => 14),
+    getFontFamilyStyle: jest.fn(() => undefined),
     onConfigChange: jest.fn(() => jest.fn()),
   },
 }));

--- a/__tests__/screens/NetworkSettingsScreen.test.tsx
+++ b/__tests__/screens/NetworkSettingsScreen.test.tsx
@@ -94,31 +94,46 @@ jest.mock('../../src/components/modals/CertificateFingerprintModal', () => ({
   },
 }));
 
-jest.mock('@react-native-picker/picker', () => ({
-  Picker: Object.assign(
-    ({ selectedValue, onValueChange, children }: any) => {
-      const { Text } = require('react-native');
-      return (
-        <>
-          <Text>Picker Value: {selectedValue}</Text>
-          <Text onPress={() => onValueChange('SCRAM-SHA-256')}>
-            Select SCRAM-SHA-256
-          </Text>
-          <Text onPress={() => onValueChange('SCRAM-SHA-256-PLUS')}>
-            Select SCRAM-SHA-256-PLUS
-          </Text>
-          {children}
-        </>
-      );
-    },
-    {
-      Item: ({ label }: any) => {
+jest.mock('@react-native-picker/picker', () => {
+  const ReactLib = require('react');
+  return {
+    Picker: Object.assign(
+      ({ selectedValue, onValueChange, children }: any) => {
         const { Text } = require('react-native');
-        return <Text>{label}</Text>;
+        // Only the SASL mechanism picker exposes the SCRAM quick-select buttons,
+        // detected from its child items so other pickers (e.g. text encoding)
+        // don't render duplicate "Select SCRAM-SHA-256" elements.
+        const isSasl = ReactLib.Children.toArray(children).some(
+          (child: any) =>
+            typeof child?.props?.value === 'string' &&
+            child.props.value.includes('SCRAM'),
+        );
+        return (
+          <>
+            <Text>Picker Value: {selectedValue}</Text>
+            {isSasl && (
+              <>
+                <Text onPress={() => onValueChange('SCRAM-SHA-256')}>
+                  Select SCRAM-SHA-256
+                </Text>
+                <Text onPress={() => onValueChange('SCRAM-SHA-256-PLUS')}>
+                  Select SCRAM-SHA-256-PLUS
+                </Text>
+              </>
+            )}
+            {children}
+          </>
+        );
       },
-    },
-  ),
-}));
+      {
+        Item: ({ label }: any) => {
+          const { Text } = require('react-native');
+          return <Text>{label}</Text>;
+        },
+      },
+    ),
+  };
+});
 
 const { settingsService } = require('../../src/services/SettingsService');
 const {

--- a/__tests__/services/EncodingService.test.ts
+++ b/__tests__/services/EncodingService.test.ts
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2025-2026 Velimir Majstorov
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { Buffer } from 'buffer';
+import {
+  encodingService,
+  SUPPORTED_ENCODINGS,
+  DEFAULT_ENCODING,
+} from '../../src/services/EncodingService';
+
+describe('EncodingService', () => {
+  describe('normalize', () => {
+    it('lower-cases and trims a supported label', () => {
+      expect(encodingService.normalize('  Windows-1251 ')).toBe('windows-1251');
+    });
+
+    it('falls back to UTF-8 for unknown or empty labels', () => {
+      expect(encodingService.normalize('made-up')).toBe(DEFAULT_ENCODING);
+      expect(encodingService.normalize('')).toBe(DEFAULT_ENCODING);
+      expect(encodingService.normalize(undefined)).toBe(DEFAULT_ENCODING);
+    });
+  });
+
+  describe('isSupported / getDisplayName', () => {
+    it('reports supported labels', () => {
+      expect(encodingService.isSupported('koi8-r')).toBe(true);
+      expect(encodingService.isSupported('nope')).toBe(false);
+    });
+
+    it('returns a friendly display name', () => {
+      expect(encodingService.getDisplayName('utf-8')).toBe('UTF-8 (Unicode)');
+      expect(encodingService.getDisplayName('windows-1251')).toContain(
+        'Windows-1251',
+      );
+    });
+  });
+
+  describe('decodeLine', () => {
+    it('decodes UTF-8 bytes', () => {
+      const bytes = Buffer.from('PRIVMSG #x :Ćao 😀', 'utf8');
+      expect(encodingService.decodeLine(bytes, 'utf-8')).toBe(
+        'PRIVMSG #x :Ćao 😀',
+      );
+    });
+
+    it('decodes Windows-1251 Cyrillic bytes', () => {
+      // "Привет" in Windows-1251.
+      const bytes = Buffer.from([0xcf, 0xf0, 0xe8, 0xe2, 0xe5, 0xf2]);
+      expect(encodingService.decodeLine(bytes, 'windows-1251')).toBe('Привет');
+    });
+
+    it('decodes ISO-8859-2 Central-European bytes', () => {
+      // "š" is 0xB9 in ISO-8859-2.
+      const bytes = Buffer.from([0xb9]);
+      expect(encodingService.decodeLine(bytes, 'iso-8859-2')).toBe('š');
+    });
+
+    it('with utf8Fallback: decodes valid UTF-8 as UTF-8', () => {
+      const bytes = Buffer.from('Ćao', 'utf8');
+      expect(encodingService.decodeLine(bytes, 'windows-1250', true)).toBe(
+        'Ćao',
+      );
+    });
+
+    it('with utf8Fallback: uses the legacy charset for invalid UTF-8', () => {
+      // 0xCF 0xF0... is not valid UTF-8, so it should decode via Windows-1251.
+      const bytes = Buffer.from([0xcf, 0xf0, 0xe8, 0xe2, 0xe5, 0xf2]);
+      expect(encodingService.decodeLine(bytes, 'windows-1251', true)).toBe(
+        'Привет',
+      );
+    });
+  });
+
+  describe('encodeForSend', () => {
+    it('returns null for UTF-8 (caller uses the string path)', () => {
+      expect(encodingService.encodeForSend('hi', 'utf-8')).toBeNull();
+    });
+
+    it('returns null when utf8Fallback prefers sending UTF-8', () => {
+      expect(
+        encodingService.encodeForSend('hi', 'windows-1251', true),
+      ).toBeNull();
+    });
+
+    it('encodes a line to legacy bytes', () => {
+      const buf = encodingService.encodeForSend('Привет', 'windows-1251');
+      expect(buf).not.toBeNull();
+      expect(Array.from(buf as Buffer)).toEqual([
+        0xcf, 0xf0, 0xe8, 0xe2, 0xe5, 0xf2,
+      ]);
+    });
+
+    it('round-trips legacy encode -> decode', () => {
+      const original = 'Čačak š đ ž';
+      const encoded = encodingService.encodeForSend(original, 'windows-1250');
+      expect(encoded).not.toBeNull();
+      const decoded = encodingService.decodeLine(
+        encoded as Buffer,
+        'windows-1250',
+      );
+      expect(decoded).toBe(original);
+    });
+  });
+
+  describe('SUPPORTED_ENCODINGS', () => {
+    it('lists UTF-8 first and has unique labels', () => {
+      expect(SUPPORTED_ENCODINGS[0].label).toBe('utf-8');
+      const labels = SUPPORTED_ENCODINGS.map(e => e.label);
+      expect(new Set(labels).size).toBe(labels.length);
+    });
+  });
+});

--- a/__tests__/services/LayoutService.test.ts
+++ b/__tests__/services/LayoutService.test.ts
@@ -381,6 +381,34 @@ describe('LayoutService', () => {
     });
   });
 
+  describe('font family', () => {
+    it('defaults to system', () => {
+      expect(layoutService.getFontFamily()).toBe('system');
+    });
+
+    it('returns undefined style for system, name otherwise', async () => {
+      expect(layoutService.getFontFamilyStyle()).toBeUndefined();
+      await layoutService.setFontFamily('monospace');
+      expect(layoutService.getFontFamily()).toBe('monospace');
+      expect(layoutService.getFontFamilyStyle()).toBe('monospace');
+    });
+
+    it('treats an empty family as system', async () => {
+      await layoutService.setFontFamily('');
+      expect(layoutService.getFontFamily()).toBe('system');
+      expect(layoutService.getFontFamilyStyle()).toBeUndefined();
+    });
+
+    it('defaults fontFamily to system when missing from saved config', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(
+        JSON.stringify({ tabPosition: 'bottom' }),
+      );
+      const fresh = new (layoutService.constructor as any)();
+      await fresh.initialize();
+      expect(fresh.getFontFamily()).toBe('system');
+    });
+  });
+
   describe('message spacing', () => {
     it('should get message spacing', () => {
       expect(layoutService.getMessageSpacing()).toBe(4);

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -263,8 +263,8 @@ android {
         applicationId = "com.androidircx"
         minSdkVersion = rootProject.ext.minSdkVersion
         targetSdkVersion = rootProject.ext.targetSdkVersion
-        versionCode = 151
-        versionName = "1.9.44"
+        versionCode = 152
+        versionName = "1.9.45"
 
         buildConfigField "long", "PLAY_INTEGRITY_PROJECT_NUMBER", "1060587657852L"
 

--- a/android/fastlane/fastlane/metadata/android/en-US/changelogs/152.txt
+++ b/android/fastlane/fastlane/metadata/android/en-US/changelogs/152.txt
@@ -1,0 +1,5 @@
+What's new in v1.9.45:
+- Choose your text encoding instead of being stuck on UTF-8 — set it per network or as a global default in Settings.
+- Supports UTF-8 plus legacy charsets: Windows-1250/1251/1252, ISO-8859-*, KOI8-R/U, Shift_JIS, GBK, Big5, EUC-KR and more.
+- Optional "Prefer UTF-8 (fallback)" mode for mixed channels.
+- New message font choice (System, Serif, Monospace and more) in Settings › Appearance.

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "name": "AndroidIRCX",
   "displayName": "AndroidIRCX",
-  "version": "1.9.44",
+  "version": "1.9.45",
   "react-native-google-mobile-ads": {
     "android_app_id": "ca-app-pub-5116758828202889~3198641840"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "androidircx",
-  "version": "1.9.44",
+  "version": "1.9.45",
   "private": true,
   "license": "GPL-3.0-or-later",
   "scripts": {

--- a/src/components/MessageArea.tsx
+++ b/src/components/MessageArea.tsx
@@ -4063,6 +4063,7 @@ const createStyles = (
   const selectionBarBottom = messageInputHeight + bottomInset + 12;
   const selectionToastBottom = selectionBarBottom + 68; // 68px above the selection bar
   const messageFontSize = layoutService.getFontSizePixels();
+  const messageFontFamily = layoutService.getFontFamilyStyle();
   const messageLineHeight = Math.ceil(messageFontSize * 1.45);
   const timestampFontSize = Math.max(10, messageFontSize - 2);
   const timestampLineHeight = Math.ceil(timestampFontSize * 1.35);
@@ -4196,6 +4197,7 @@ const createStyles = (
     nick: {
       color: colors.messageNick,
       fontSize: messageFontSize,
+      fontFamily: messageFontFamily,
       lineHeight: messageLineHeight,
       fontWeight: '600',
       marginRight: 8,
@@ -4204,6 +4206,7 @@ const createStyles = (
     messageText: {
       color: colors.messageText,
       fontSize: messageFontSize,
+      fontFamily: messageFontFamily,
       lineHeight: messageLineHeight,
       flex: 1,
       flexShrink: 1,
@@ -4213,6 +4216,7 @@ const createStyles = (
     messageTextInline: {
       color: colors.messageText,
       fontSize: messageFontSize,
+      fontFamily: messageFontFamily,
       lineHeight: messageLineHeight,
       textAlign: layoutConfig.messageTextAlign || 'left',
       writingDirection: layoutConfig.messageTextDirection || 'auto',

--- a/src/components/settings/sections/AppearanceSection.tsx
+++ b/src/components/settings/sections/AppearanceSection.tsx
@@ -39,6 +39,26 @@ import {
 } from '@react-native-documents/picker';
 import RNFS from 'react-native-fs';
 
+// Message font family choices. Values are Android built-in family names ('system'
+// maps to the platform default); no font assets are bundled. Labels are English
+// source strings passed through t() at render time.
+const MESSAGE_FONT_OPTIONS: Array<{ value: string; label: string }> = [
+  { value: 'system', label: 'System default' },
+  { value: 'sans-serif', label: 'Sans-serif' },
+  { value: 'sans-serif-medium', label: 'Sans-serif Medium' },
+  { value: 'sans-serif-condensed', label: 'Condensed' },
+  { value: 'serif', label: 'Serif' },
+  { value: 'monospace', label: 'Monospace' },
+];
+
+const MESSAGE_FONT_LABELS: Record<string, string> = MESSAGE_FONT_OPTIONS.reduce(
+  (map, option) => {
+    map[option.value] = option.label;
+    return map;
+  },
+  {} as Record<string, string>,
+);
+
 interface AppearanceSectionProps {
   colors: {
     text: string;
@@ -664,6 +684,35 @@ export const AppearanceSection: React.FC<AppearanceSectionProps> = ({
             },
           },
         ],
+      },
+      {
+        id: 'layout-message-font',
+        title: t('Message Font', { _tags: tags }),
+        description: t('Font: {font}', {
+          font:
+            MESSAGE_FONT_LABELS[layoutConfig?.fontFamily || 'system'] ||
+            t('System default', { _tags: tags }),
+          _tags: tags,
+        }),
+        type: 'submenu',
+        searchKeywords: [
+          'font',
+          'family',
+          'typeface',
+          'monospace',
+          'serif',
+          'message',
+          'text',
+        ],
+        submenuItems: MESSAGE_FONT_OPTIONS.map(option => ({
+          id: `layout-message-font-${option.value}`,
+          title: t(option.label, { _tags: tags }),
+          type: 'button' as const,
+          onPress: async () => {
+            await layoutService.setFontFamily(option.value);
+            updateLayoutConfig({});
+          },
+        })),
       },
       {
         id: 'layout-userlist-position',

--- a/src/components/settings/sections/ConnectionNetworkSection.tsx
+++ b/src/components/settings/sections/ConnectionNetworkSection.tsx
@@ -64,6 +64,10 @@ import { secureStorageService } from '../../../services/SecureStorageService';
 import { connectionManager } from '../../../services/ConnectionManager';
 import { serviceDetectionService } from '../../../services/ServiceDetectionService';
 import { useUIStore } from '../../../stores/uiStore';
+import {
+  SUPPORTED_ENCODINGS,
+  encodingService,
+} from '../../../services/EncodingService';
 
 interface ConnectionNetworkSectionProps {
   colors: {
@@ -303,6 +307,25 @@ export const ConnectionNetworkSection: React.FC<
     );
     setAllFavorites(flattened);
     setFavoritesCount(flattened.length);
+  }, []);
+
+  // Global default text encoding (used by networks without an explicit override)
+  const [defaultEncoding, setDefaultEncodingState] = useState('utf-8');
+  const [defaultUtf8Fallback, setDefaultUtf8FallbackState] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    (async () => {
+      const enc = await settingsService.getSetting('defaultEncoding', 'utf-8');
+      const fb = await settingsService.getSetting('defaultUtf8Fallback', false);
+      if (active) {
+        setDefaultEncodingState(encodingService.normalize(enc));
+        setDefaultUtf8FallbackState(Boolean(fb));
+      }
+    })();
+    return () => {
+      active = false;
+    };
   }, []);
 
   // Load initial state
@@ -1376,6 +1399,51 @@ export const ConnectionNetworkSection: React.FC<
           'choose',
         ],
         onPress: openQuickConnectModal,
+      },
+      {
+        id: 'default-encoding',
+        title: t('Default Text Encoding', { _tags: tags }),
+        description: t('Default: {encoding}', {
+          encoding: encodingService.getDisplayName(defaultEncoding),
+          _tags: tags,
+        }),
+        type: 'submenu',
+        searchKeywords: [
+          'encoding',
+          'charset',
+          'utf-8',
+          'unicode',
+          'cyrillic',
+          'latin',
+          'windows-1251',
+          'iso-8859',
+          'text',
+        ],
+        submenuItems: SUPPORTED_ENCODINGS.map(option => ({
+          id: `default-encoding-${option.label}`,
+          title: option.name,
+          type: 'button' as const,
+          onPress: async () => {
+            setDefaultEncodingState(option.label);
+            await settingsService.setSetting('defaultEncoding', option.label);
+          },
+        })),
+      },
+      {
+        id: 'default-utf8-fallback',
+        title: t('Prefer UTF-8 (fallback to encoding)', { _tags: tags }),
+        description: t(
+          'Read messages as UTF-8 and only use the selected encoding for text that is not valid UTF-8. Ignored when the encoding is UTF-8.',
+          { _tags: tags },
+        ),
+        type: 'switch',
+        value: defaultUtf8Fallback,
+        searchKeywords: ['utf-8', 'fallback', 'encoding', 'mixed', 'charset'],
+        onValueChange: async (value: string | boolean) => {
+          const enabled = Boolean(value);
+          setDefaultUtf8FallbackState(enabled);
+          await settingsService.setSetting('defaultUtf8Fallback', enabled);
+        },
       },
       {
         id: 'connection-auto-connect-favorite',
@@ -2457,6 +2525,8 @@ export const ConnectionNetworkSection: React.FC<
     onShowNetworksList,
     onShowConnectionProfiles,
     quickConnectNetworkId,
+    defaultEncoding,
+    defaultUtf8Fallback,
     t,
     tags,
   ]);

--- a/src/hooks/useConnectionHandler.ts
+++ b/src/hooks/useConnectionHandler.ts
@@ -276,6 +276,20 @@ export const useConnectionHandler = (params: UseConnectionHandlerParams) => {
       } as any);
       const proxyToUse = networkToUse.proxy || globalProxy || null;
 
+      // Resolve character encoding: per-network override, else global default.
+      const defaultEncoding = await settingsService.getSetting(
+        'defaultEncoding',
+        'utf-8',
+      );
+      const defaultUtf8Fallback = await settingsService.getSetting(
+        'defaultUtf8Fallback',
+        false,
+      );
+      const encodingToUse = networkToUse.encoding || defaultEncoding;
+      const utf8FallbackToUse = networkToUse.encoding
+        ? Boolean(networkToUse.utf8Fallback)
+        : Boolean(defaultUtf8Fallback);
+
       const config: IRCConnectionConfig = {
         host: (serverToUse.hostname || '').trim(),
         port: serverToUse.port,
@@ -294,6 +308,8 @@ export const useConnectionHandler = (params: UseConnectionHandlerParams) => {
         webirc: networkToUse.webirc,
         clientCert: networkToUse.clientCert,
         clientKey: networkToUse.clientKey,
+        encoding: encodingToUse,
+        utf8Fallback: utf8FallbackToUse,
       };
 
       try {

--- a/src/screens/NetworkSettingsScreen.tsx
+++ b/src/screens/NetworkSettingsScreen.tsx
@@ -29,6 +29,7 @@ import { CertificateFingerprintModal } from '../components/modals/CertificateFin
 import { certificateManager } from '../services/CertificateManagerService';
 import type { CertificateInfo } from '../types/certificate';
 import { Picker } from '@react-native-picker/picker';
+import { SUPPORTED_ENCODINGS } from '../services/EncodingService';
 import { useTheme } from '../hooks/useTheme';
 
 interface NetworkSettingsScreenProps {
@@ -75,6 +76,9 @@ export const NetworkSettingsScreen: React.FC<NetworkSettingsScreenProps> = ({
   >('PLAIN');
   const [clientCert, setClientCert] = useState('');
   const [clientKey, setClientKey] = useState('');
+  // '' means "use the global default encoding".
+  const [encoding, setEncoding] = useState('');
+  const [utf8Fallback, setUtf8Fallback] = useState(false);
   const [proxyEnabled, setProxyEnabled] = useState(false);
   const [proxyType, setProxyType] = useState('tor');
   const [proxyHost, setProxyHost] = useState('127.0.0.1');
@@ -126,6 +130,8 @@ export const NetworkSettingsScreen: React.FC<NetworkSettingsScreenProps> = ({
         setSaslMechanism(network.sasl?.mechanism || 'PLAIN');
         setClientCert(network.clientCert || '');
         setClientKey(network.clientKey || '');
+        setEncoding(network.encoding || '');
+        setUtf8Fallback(Boolean(network.utf8Fallback));
         setProxyEnabled(
           network.proxy ? network.proxy.enabled !== false : false,
         );
@@ -298,6 +304,8 @@ export const NetworkSettingsScreen: React.FC<NetworkSettingsScreenProps> = ({
           : undefined,
       clientCert: clientCert.trim() || undefined,
       clientKey: clientKey.trim() || undefined,
+      encoding: encoding || undefined,
+      utf8Fallback: encoding ? utf8Fallback : undefined,
       transport: webSocketEnabled ? 'websocket' : 'tcp',
       webSocketUrl:
         webSocketEnabled && webSocketUrl.trim()
@@ -475,6 +483,42 @@ export const NetworkSettingsScreen: React.FC<NetworkSettingsScreenProps> = ({
               <Text style={styles.sectionTitle}>
                 {t('SASL Authentication (Optional)')}
               </Text>
+
+              <View style={styles.inputGroup}>
+                <Text style={styles.label}>{t('Text Encoding')}</Text>
+                <View style={styles.pickerContainer}>
+                  <Picker
+                    selectedValue={encoding}
+                    onValueChange={value => setEncoding(value)}
+                    style={[styles.picker, { color: colors.text }]}
+                  >
+                    <Picker.Item label={t('Use global default')} value="" />
+                    {SUPPORTED_ENCODINGS.map(option => (
+                      <Picker.Item
+                        key={option.label}
+                        label={option.name}
+                        value={option.label}
+                      />
+                    ))}
+                  </Picker>
+                </View>
+              </View>
+
+              {encoding !== '' && encoding !== 'utf-8' && (
+                <View style={styles.switchRow}>
+                  <Text style={styles.label}>
+                    {t('Prefer UTF-8 (fallback to encoding)')}
+                  </Text>
+                  <Switch
+                    value={utf8Fallback}
+                    onValueChange={setUtf8Fallback}
+                    trackColor={{ false: colors.border, true: colors.accent }}
+                    thumbColor={
+                      utf8Fallback ? colors.onAccent : colors.surfaceVariant
+                    }
+                  />
+                </View>
+              )}
 
               <View style={styles.inputGroup}>
                 <Text style={styles.label}>{t('SASL Mechanism')}</Text>

--- a/src/services/EncodingService.ts
+++ b/src/services/EncodingService.ts
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) 2025-2026 Velimir Majstorov
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * EncodingService.ts
+ *
+ * Character-encoding support for IRC traffic. IRC is a byte protocol with no
+ * in-band charset negotiation, so different networks/users send text in
+ * different legacy encodings (ISO-8859-*, Windows-125x, KOI8, Shift_JIS, ...).
+ * This service decodes incoming line bytes and encodes outgoing lines using a
+ * per-connection encoding, with an optional "prefer UTF-8, fall back to legacy"
+ * mode for mixed channels.
+ *
+ * Backed by the already-bundled `text-encoding` polyfill, which supports the
+ * full WHATWG decoder set and legacy encoding via NONSTANDARD_allowLegacyEncoding.
+ * Decoding is done per complete IRC line (split on LF before decoding), so no
+ * streaming state is needed and multi-byte characters never straddle a chunk
+ * boundary — all supported encodings keep 0x0A/0x0D as ASCII control bytes.
+ */
+
+import { Buffer } from 'buffer';
+import { TextDecoder, TextEncoder } from 'text-encoding';
+import { logger } from './Logger';
+
+// The `text-encoding` runtime supports constructor options that its bundled d.ts
+// omits: TextDecoder(label, { fatal }) and the non-standard legacy encoder
+// TextEncoder(label, { NONSTANDARD_allowLegacyEncoding }). Type the constructors
+// to match the real API.
+const TextDecoderCtor = TextDecoder as unknown as new (
+  label?: string,
+  options?: { fatal?: boolean },
+) => TextDecoder;
+const TextEncoderCtor = TextEncoder as unknown as new (
+  label?: string,
+  options?: { NONSTANDARD_allowLegacyEncoding?: boolean },
+) => TextEncoder;
+
+export const DEFAULT_ENCODING = 'utf-8';
+
+export interface EncodingOption {
+  /** WHATWG label understood by text-encoding (also what we persist). */
+  label: string;
+  /** Human-readable name shown in settings. */
+  name: string;
+}
+
+/**
+ * Curated list of encodings offered in the UI, ordered by how common they are
+ * on IRC. `utf-8` is the modern default; the rest are legacy charsets still
+ * used on older networks and by older clients.
+ */
+export const SUPPORTED_ENCODINGS: EncodingOption[] = [
+  { label: 'utf-8', name: 'UTF-8 (Unicode)' },
+  { label: 'iso-8859-1', name: 'Western (ISO-8859-1)' },
+  { label: 'iso-8859-15', name: 'Western (ISO-8859-15)' },
+  { label: 'windows-1252', name: 'Western (Windows-1252)' },
+  { label: 'iso-8859-2', name: 'Central European (ISO-8859-2)' },
+  { label: 'windows-1250', name: 'Central European (Windows-1250)' },
+  { label: 'windows-1251', name: 'Cyrillic (Windows-1251)' },
+  { label: 'koi8-r', name: 'Cyrillic (KOI8-R)' },
+  { label: 'koi8-u', name: 'Cyrillic (KOI8-U)' },
+  { label: 'iso-8859-5', name: 'Cyrillic (ISO-8859-5)' },
+  { label: 'iso-8859-7', name: 'Greek (ISO-8859-7)' },
+  { label: 'windows-1253', name: 'Greek (Windows-1253)' },
+  { label: 'iso-8859-9', name: 'Turkish (ISO-8859-9)' },
+  { label: 'windows-1254', name: 'Turkish (Windows-1254)' },
+  { label: 'windows-1257', name: 'Baltic (Windows-1257)' },
+  { label: 'shift_jis', name: 'Japanese (Shift_JIS)' },
+  { label: 'euc-jp', name: 'Japanese (EUC-JP)' },
+  { label: 'gbk', name: 'Chinese Simplified (GBK)' },
+  { label: 'big5', name: 'Chinese Traditional (Big5)' },
+  { label: 'euc-kr', name: 'Korean (EUC-KR)' },
+];
+
+const SUPPORTED_LABELS = new Set(SUPPORTED_ENCODINGS.map(e => e.label));
+
+class EncodingService {
+  // Cached decoder/encoder instances keyed by label (non-streaming, reusable).
+  private decoders = new Map<string, TextDecoder>();
+  private encoders = new Map<string, TextEncoder>();
+  private utf8Fatal: TextDecoder | null = null;
+  private utf8Loose: TextDecoder | null = null;
+
+  /** Whether a label is one we offer / can handle. */
+  isSupported(label: string): boolean {
+    return SUPPORTED_LABELS.has((label || '').toLowerCase().trim());
+  }
+
+  /** Normalize a persisted label to a canonical, lower-case form. */
+  normalize(label: string | undefined | null): string {
+    const value = (label || DEFAULT_ENCODING).toLowerCase().trim();
+    return SUPPORTED_LABELS.has(value) ? value : DEFAULT_ENCODING;
+  }
+
+  /** Display name for a label (falls back to the raw label). */
+  getDisplayName(label: string): string {
+    const normalized = this.normalize(label);
+    return (
+      SUPPORTED_ENCODINGS.find(e => e.label === normalized)?.name || normalized
+    );
+  }
+
+  private getUtf8Loose(): TextDecoder {
+    if (!this.utf8Loose) {
+      this.utf8Loose = new TextDecoderCtor('utf-8', { fatal: false });
+    }
+    return this.utf8Loose;
+  }
+
+  private getUtf8Fatal(): TextDecoder {
+    if (!this.utf8Fatal) {
+      this.utf8Fatal = new TextDecoderCtor('utf-8', { fatal: true });
+    }
+    return this.utf8Fatal;
+  }
+
+  private getDecoder(label: string): TextDecoder {
+    const normalized = this.normalize(label);
+    let decoder = this.decoders.get(normalized);
+    if (!decoder) {
+      try {
+        decoder = new TextDecoderCtor(normalized, { fatal: false });
+      } catch (error) {
+        logger.warn(
+          'encoding',
+          `Unknown decoder "${normalized}", using UTF-8: ${String(error)}`,
+        );
+        decoder = this.getUtf8Loose();
+      }
+      this.decoders.set(normalized, decoder);
+    }
+    return decoder;
+  }
+
+  private getLegacyEncoder(label: string): TextEncoder | null {
+    const normalized = this.normalize(label);
+    if (normalized === 'utf-8') {
+      return null;
+    }
+    let encoder = this.encoders.get(normalized);
+    if (!encoder) {
+      try {
+        encoder = new TextEncoderCtor(normalized, {
+          NONSTANDARD_allowLegacyEncoding: true,
+        });
+      } catch (error) {
+        logger.warn(
+          'encoding',
+          `Cannot build legacy encoder "${normalized}": ${String(error)}`,
+        );
+        return null;
+      }
+      this.encoders.set(normalized, encoder);
+    }
+    return encoder;
+  }
+
+  /**
+   * Decode the bytes of a single IRC line to a string.
+   *
+   * @param bytes      the raw line bytes (without the trailing CRLF)
+   * @param encoding   the connection encoding label
+   * @param utf8Fallback when true and `encoding` is a legacy charset, decode as
+   *                   UTF-8 first and only fall back to the legacy charset if the
+   *                   bytes are not valid UTF-8 (per line). Ignored for utf-8.
+   */
+  decodeLine(
+    bytes: Uint8Array,
+    encoding: string,
+    utf8Fallback: boolean = false,
+  ): string {
+    const normalized = this.normalize(encoding);
+    if (normalized === 'utf-8') {
+      return this.getUtf8Loose().decode(bytes);
+    }
+    if (utf8Fallback) {
+      try {
+        return this.getUtf8Fatal().decode(bytes);
+      } catch {
+        // Not valid UTF-8 — decode this line with the legacy charset instead.
+      }
+    }
+    return this.getDecoder(normalized).decode(bytes);
+  }
+
+  /**
+   * Encode an outgoing IRC line for the wire.
+   *
+   * Returns a Buffer of legacy bytes, or `null` when the caller should use the
+   * plain UTF-8 string write path (encoding is utf-8, or utf8Fallback prefers
+   * sending UTF-8). Returning null keeps the common UTF-8 path byte-identical
+   * to the previous behavior.
+   */
+  encodeForSend(
+    line: string,
+    encoding: string,
+    utf8Fallback: boolean = false,
+  ): Buffer | null {
+    const normalized = this.normalize(encoding);
+    if (normalized === 'utf-8' || utf8Fallback) {
+      return null;
+    }
+    const encoder = this.getLegacyEncoder(normalized);
+    if (!encoder) {
+      return null;
+    }
+    try {
+      return Buffer.from(encoder.encode(line));
+    } catch (error) {
+      logger.warn(
+        'encoding',
+        `Failed to encode line as "${normalized}", sending UTF-8: ${String(error)}`,
+      );
+      return null;
+    }
+  }
+}
+
+export const encodingService = new EncodingService();

--- a/src/services/IRCService.ts
+++ b/src/services/IRCService.ts
@@ -5,6 +5,8 @@
 
 import TcpSocket from 'react-native-tcp-socket';
 import type TLSSocket from 'react-native-tcp-socket/lib/types/TLSSocket';
+import { Buffer } from 'buffer';
+import { encodingService, DEFAULT_ENCODING } from './EncodingService';
 import {
   DEFAULT_PART_MESSAGE,
   DEFAULT_QUIT_MESSAGE,
@@ -79,6 +81,12 @@ export interface IRCConnectionConfig {
     mechanism?: 'PLAIN' | 'SCRAM-SHA-256' | 'SCRAM-SHA-256-PLUS' | 'EXTERNAL';
     force?: boolean; // Force SASL even if server doesn't advertise capability
   };
+  // Character encoding for wire text (WHATWG label, e.g. 'utf-8',
+  // 'windows-1251'). When utf8Fallback is true and encoding is a legacy
+  // charset, incoming lines are decoded as UTF-8 first and only fall back to
+  // the legacy charset per line, and outgoing lines are sent as UTF-8.
+  encoding?: string;
+  utf8Fallback?: boolean;
 }
 
 export type ChatHistorySubcommand =
@@ -260,8 +268,10 @@ export class IRCService {
   private messageListeners: ((message: IRCMessage) => void)[] = [];
   private connectionListeners: ((connected: boolean) => void)[] = [];
   private eventListeners: Map<string, Function[]> = new Map();
-  private buffer: string = '';
-  private socketTextDecoder: TextDecoder | null = null;
+  // Raw inbound bytes accumulated until a full line (LF) is available. Lines
+  // are decoded with the connection encoding (see EncodingService) so legacy
+  // charsets and the UTF-8 fallback mode work correctly.
+  private inboundBuffer: Buffer = Buffer.alloc(0);
   private registered: boolean = false;
   private currentNick: string = '';
   private altNick: string = '';
@@ -825,11 +835,7 @@ export class IRCService {
 
         this.config = config;
         this.registered = false;
-        this.buffer = '';
-        this.socketTextDecoder =
-          typeof TextDecoder !== 'undefined'
-            ? new TextDecoder('utf-8', { fatal: false })
-            : null;
+        this.inboundBuffer = Buffer.alloc(0);
 
         this.capNegotiating = false;
         this.capEnabled = false;
@@ -913,26 +919,20 @@ export class IRCService {
           }
 
           this.socket.on('data', (data: any) => {
-            let dataStr: string;
+            // Accumulate raw bytes; lines are decoded in processBuffer() using
+            // the connection encoding. tcp-socket delivers a Buffer/Uint8Array
+            // by default (no setEncoding), but handle a string just in case.
+            let chunk: Buffer;
             if (typeof data === 'string') {
-              dataStr = data;
-            } else if (
-              this.socketTextDecoder &&
-              data &&
-              data.buffer !== undefined
-            ) {
-              try {
-                dataStr = this.socketTextDecoder.decode(
-                  data instanceof Uint8Array ? data : new Uint8Array(data),
-                  { stream: true },
-                );
-              } catch {
-                dataStr = data.toString();
-              }
+              chunk = Buffer.from(data, 'utf8');
+            } else if (Buffer.isBuffer(data)) {
+              chunk = data;
             } else {
-              dataStr = data.toString();
+              chunk = Buffer.from(
+                data instanceof Uint8Array ? data : new Uint8Array(data),
+              );
             }
-            this.buffer += dataStr;
+            this.inboundBuffer = Buffer.concat([this.inboundBuffer, chunk]);
             this.processBuffer();
           });
 
@@ -1000,7 +1000,7 @@ export class IRCService {
             this.cleanupConnectionTimers();
             if (this.manualDisconnect) {
               this.manualDisconnect = false;
-              this.socketTextDecoder = null;
+              this.inboundBuffer = Buffer.alloc(0);
               this.stopKeepAlive();
               this.isConnected = false;
               this.registered = false;
@@ -1018,7 +1018,7 @@ export class IRCService {
             this.isConnected = false;
             this.registered = false;
             this.socket = null;
-            this.socketTextDecoder = null;
+            this.inboundBuffer = Buffer.alloc(0);
             this.stopKeepAlive();
             this.emitConnection(false);
 
@@ -1130,7 +1130,7 @@ export class IRCService {
             this.isConnected = false;
             this.registered = false;
             this.socket = null;
-            this.socketTextDecoder = null;
+            this.inboundBuffer = Buffer.alloc(0);
             this.stopKeepAlive();
             this.emitConnection(false);
           };
@@ -1311,14 +1311,10 @@ export class IRCService {
     if (typeof data === 'string') {
       dataStr = data;
     } else if (data instanceof ArrayBuffer) {
-      const bytes = new Uint8Array(data);
-      dataStr = this.socketTextDecoder
-        ? this.socketTextDecoder.decode(bytes)
-        : Buffer.from(bytes).toString('utf8');
+      // WebSocket transport uses UTF-8 (IRCv3 text.ircv3.net is UTF-8 by spec).
+      dataStr = Buffer.from(new Uint8Array(data)).toString('utf8');
     } else if (data instanceof Uint8Array) {
-      dataStr = this.socketTextDecoder
-        ? this.socketTextDecoder.decode(data)
-        : Buffer.from(data).toString('utf8');
+      dataStr = Buffer.from(data).toString('utf8');
     } else if (data && typeof (data as any).toString === 'function') {
       dataStr = (data as any).toString();
     }
@@ -1481,17 +1477,31 @@ export class IRCService {
 
   private processBuffer(): void {
     this.lastInboundActivityAt = Date.now();
-    // Support both CRLF and LF line endings from servers/proxies
-    const lines = this.buffer.split(/\r?\n/);
-    this.buffer = lines.pop() || '';
 
-    if (this.buffer.length > 8192) {
-      this.logRaw(
-        `IRCService: Large partial line buffer detected (${this.buffer.length} chars)`,
+    const encoding = encodingService.normalize(
+      this.config?.encoding || DEFAULT_ENCODING,
+    );
+    const utf8Fallback = Boolean(this.config?.utf8Fallback);
+
+    // Split the byte buffer on LF (0x0A). All supported encodings keep 0x0A and
+    // 0x0D as ASCII control bytes, so line splitting is safe before decoding,
+    // and decoding a whole line keeps multi-byte characters intact.
+    let start = 0;
+    let newlineIndex: number;
+    while ((newlineIndex = this.inboundBuffer.indexOf(0x0a, start)) !== -1) {
+      let end = newlineIndex;
+      // Strip a trailing CR (0x0D) so CRLF and LF are both handled.
+      if (end > start && this.inboundBuffer[end - 1] === 0x0d) {
+        end -= 1;
+      }
+      const lineBytes = this.inboundBuffer.subarray(start, end);
+      start = newlineIndex + 1;
+
+      const line = encodingService.decodeLine(
+        lineBytes,
+        encoding,
+        utf8Fallback,
       );
-    }
-
-    for (const line of lines) {
       const trimmed = line.trim();
       if (trimmed) {
         if (line.length > 900) {
@@ -1505,6 +1515,18 @@ export class IRCService {
         // Show blank lines for troubleshooting proxy/http responses
         this.addWireMessage('in', t('(empty line)'));
       }
+    }
+
+    // Keep the trailing partial line (bytes after the last LF) for next chunk.
+    this.inboundBuffer =
+      start > 0
+        ? Buffer.from(this.inboundBuffer.subarray(start))
+        : this.inboundBuffer;
+
+    if (this.inboundBuffer.length > 8192) {
+      this.logRaw(
+        `IRCService: Large partial line buffer detected (${this.inboundBuffer.length} bytes)`,
+      );
     }
   }
 
@@ -2519,13 +2541,48 @@ export class IRCService {
       ));
   }
 
+  /**
+   * Write a single IRC line to the TCP socket, encoded with the connection
+   * encoding. For UTF-8 (or the UTF-8-fallback mode, which sends UTF-8)
+   * encodeForSend returns null and we keep the plain string write so the common
+   * path is byte-identical to the previous behavior.
+   */
+  private writeEncodedLine(message: string): void {
+    const encoded = encodingService.encodeForSend(
+      message,
+      this.config?.encoding || DEFAULT_ENCODING,
+      Boolean(this.config?.utf8Fallback),
+    );
+    if (encoded) {
+      this.socket.write(Buffer.concat([encoded, Buffer.from('\r\n', 'ascii')]));
+    } else {
+      this.socket.write(message + '\r\n');
+    }
+  }
+
+  /**
+   * Update the active connection encoding on the fly (e.g. when the user
+   * changes the per-network encoding while connected). Applies to subsequent
+   * inbound lines and outbound writes; already-decoded messages are unaffected.
+   */
+  public setEncoding(encoding: string, utf8Fallback: boolean = false): void {
+    if (this.config) {
+      this.config = {
+        ...this.config,
+        encoding: encodingService.normalize(encoding),
+        utf8Fallback,
+      };
+    }
+  }
+
   public sendRaw(message: string): void {
     if (this.socket && this.isConnected) {
       try {
         if (this.currentTransport === 'websocket' && this.socket.send) {
+          // WebSocket transport is UTF-8 by spec.
           this.socket.send(message);
         } else {
-          this.socket.write(message + '\r\n');
+          this.writeEncodedLine(message);
         }
         this.addWireMessage('out', message);
         this.emit('send-raw', message);
@@ -2564,7 +2621,7 @@ export class IRCService {
         if (this.currentTransport === 'websocket' && this.socket.send) {
           this.socket.send(`WHO ${nick}`);
         } else {
-          this.socket.write(`WHO ${nick}\r\n`);
+          this.writeEncodedLine(`WHO ${nick}`);
         }
         // Don't call addWireMessage - this keeps it silent
         this.emit('send-raw', `WHO ${nick}`);
@@ -2593,7 +2650,7 @@ export class IRCService {
         if (this.currentTransport === 'websocket' && this.socket.send) {
           this.socket.send(`MODE ${nick}`);
         } else {
-          this.socket.write(`MODE ${nick}\r\n`);
+          this.writeEncodedLine(`MODE ${nick}`);
         }
         // Don't call addWireMessage - this keeps it silent
         this.emit('send-raw', `MODE ${nick}`);
@@ -2663,7 +2720,7 @@ export class IRCService {
 
   disconnect(message?: string): void {
     this.manualDisconnect = true;
-    this.socketTextDecoder = null;
+    this.inboundBuffer = Buffer.alloc(0);
     this.stopKeepAlive();
     this.cleanupConnectionTimers();
     if (this.socket) {

--- a/src/services/LayoutService.ts
+++ b/src/services/LayoutService.ts
@@ -18,6 +18,9 @@ export interface LayoutConfig {
   userListNickFontSizePx: number; // Nick font size in the user list
   viewMode: ViewMode;
   fontSize: FontSize;
+  // Message font family. 'system' uses the platform default; other values are
+  // Android built-in family names (e.g. 'monospace', 'serif', 'sans-serif').
+  fontFamily: string;
   fontSizeValues: {
     small: number;
     medium: number;
@@ -44,6 +47,7 @@ class LayoutService {
     userListNickFontSizePx: 13,
     viewMode: 'comfortable',
     fontSize: 'medium',
+    fontFamily: 'system',
     fontSizeValues: {
       small: 12,
       medium: 14,
@@ -123,6 +127,9 @@ class LayoutService {
           }
           if (!data.messageTextDirection) {
             this.config.messageTextDirection = 'auto';
+          }
+          if (!data.fontFamily) {
+            this.config.fontFamily = 'system';
           }
         }
       } catch (error) {
@@ -257,6 +264,29 @@ class LayoutService {
    */
   async setFontSize(size: FontSize): Promise<void> {
     await this.setConfig({ fontSize: size });
+  }
+
+  /**
+   * Get the message font family ('system' or an Android family name).
+   */
+  getFontFamily(): string {
+    return this.config.fontFamily || 'system';
+  }
+
+  /**
+   * Resolve the font family to a React Native style value: undefined for the
+   * platform default ('system'), otherwise the family name.
+   */
+  getFontFamilyStyle(): string | undefined {
+    const family = this.config.fontFamily;
+    return !family || family === 'system' ? undefined : family;
+  }
+
+  /**
+   * Set the message font family.
+   */
+  async setFontFamily(fontFamily: string): Promise<void> {
+    await this.setConfig({ fontFamily: fontFamily || 'system' });
   }
 
   /**

--- a/src/services/SettingsService.ts
+++ b/src/services/SettingsService.ts
@@ -82,6 +82,12 @@ export interface IRCNetworkConfig {
   // If auto-detect is true (default), Undernet detection enables double-nick format automatically.
   whoisAutoDetectDoubleNick?: boolean;
   whoisUseDoubleNick?: boolean;
+  // Character encoding for this network's wire text (WHATWG label, e.g.
+  // 'utf-8', 'windows-1251'). Undefined means "use the global default".
+  encoding?: string;
+  // When true and `encoding` is a legacy charset, decode incoming lines as
+  // UTF-8 first and only fall back to the legacy charset per line; send UTF-8.
+  utf8Fallback?: boolean;
 }
 
 const STORAGE_KEY = '@AndroidIRCX:networks';


### PR DESCRIPTION
## Summary

Users could not change the character encoding — inbound bytes were decoded with the global UTF-8 `TextDecoder` and `sendRaw` sent UTF-8, so legacy charsets showed as mojibake and there was no way to change it. This adds selectable text encoding (per-network + global default), an optional UTF-8-fallback mode, and a message font choice.

## Encoding
- **`EncodingService`** (new): wraps the already-bundled `text-encoding` polyfill (no new dependency). Supports UTF-8 + ~19 legacy charsets (Windows-1250/1251/1252/1253/1254/1257, ISO-8859-1/2/5/7/9/15, KOI8-R/U, Shift_JIS, EUC-JP, GBK, Big5, EUC-KR). Legacy encoding via `NONSTANDARD_allowLegacyEncoding`.
- **`IRCService`**: receive path now buffers raw bytes and decodes per line (split on LF; all supported charsets keep CR/LF as ASCII), replacing the string buffer + UTF-8-only `socketTextDecoder`. `sendRaw` and silent WHO/MODE route through `writeEncodedLine`. Added `encoding`/`utf8Fallback` to `IRCConnectionConfig` + live `setEncoding()`. WebSocket stays UTF-8 (IRCv3 `text.ircv3.net` is UTF-8 by spec).
- **Config**: per-network `encoding`/`utf8Fallback` on `IRCNetworkConfig`; global `defaultEncoding`/`defaultUtf8Fallback` settings; `useConnectionHandler` resolves per-network override else global at connect. Encoding applies on next (re)connect.
- **UI**: global default + fallback switch in `ConnectionNetworkSection`; per-network Picker + fallback switch in `NetworkSettingsScreen` (with "Use global default").

## Message font
- `LayoutService.fontFamily` (default `system`) + `getFontFamilyStyle()`; applied to nick/message text in `MessageArea`; Picker in `AppearanceSection` (Android built-in families, no bundled assets).

## Version
- 1.9.44 → **1.9.45** (versionCode 151 → 152) + changelog `152.txt`.

## Tests
- New `EncodingService` suite (100%: round-trips CP1251/ISO-8859-2/Windows-1250, UTF-8-fallback both branches). `IRCService.lowlevel` byte-buffer/encode paths. `LayoutService` fontFamily.
- Local gate green: type-check, lint:ci, prettier, **test:ci 7396 passed / 19 skipped**, coverage ~93.9%.
- Release build (AAB + APK) succeeded; native-lib check passed; smoke-tested on device.

## Notes
- No new dependency and no native/asset changes, so a clean build is not required.
- WebSocket transport and DCC chat encoding are intentionally out of scope for this change.